### PR TITLE
修复查询中文只显示最后一条的问题

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -9,7 +9,7 @@ parser.parse = function (isChinese, body) {
 	let result = ''
 	if (isChinese) {
 		$('div.trans-container > ul').find('p.wordGroup').each(function (i, elm) {
-			result = $(this).text().replace(/\s+/g, ' ')
+			result += $(this).text().replace(/\s+/g, ' ')
 		})
 	} else {
 		result = $('div#phrsListTab > div.trans-container > ul').text()


### PR DESCRIPTION
有道上中文查询显示英文和英文查询显示中文的样式是不一样的
中文查询后使用 `each`遍历需要把结果加起来